### PR TITLE
Change pip3 to pip (problems encountered by novice operation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,13 @@ Videos are downsampled to `.gif` for display. Click for original videos. Prompts
 ```bash
 # create a virtual env
 conda create -n opensora python=3.10
+# activate virtual environmen
+conda activate opensora
 
 # install torch
 # the command below is for CUDA 12.1, choose install commands from 
 # https://pytorch.org/get-started/locally/ based on your own CUDA version
-pip3 install torch torchvision
+pip install torch torchvision
 
 # install flash attention (optional)
 pip install packaging ninja
@@ -106,7 +108,7 @@ pip install flash-attn --no-build-isolation
 pip install -v --disable-pip-version-check --no-cache-dir --no-build-isolation --config-settings "--build-option=--cpp_ext" --config-settings "--build-option=--cuda_ext" git+https://github.com/NVIDIA/apex.git
 
 # install xformers
-pip3 install -U xformers --index-url https://download.pytorch.org/whl/cu121
+pip install -U xformers --index-url https://download.pytorch.org/whl/cu121
 
 # install this project
 git clone https://github.com/hpcaitech/Open-Sora


### PR DESCRIPTION
Recommend to colleagues (server) for trial, install according to the installation method and encounter various questions

1. Following the instructions provided by install, the environment was not activated (it was just a copy and paste session)

2. What is the relationship between pip and pip3 (normally two different tools, pointing to the same tool in the conda environment, which is a bit difficult to explain)

Also, using xforms on Mac is very difficult!!