### PR TITLE
pip install gradio in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ on improving the quality and text alignment.
 We have provided a Gradio application in this repository, you can use the following the command to start an interactive web application to experience video generation with Open-Sora.
 
 ```bash
+pip install gradio
 python scripts/demo.py
 ```
 


### PR DESCRIPTION
The gradio is not installed using requirements.txt file. Installing it before using scripts/demo.py, so that it does not throw any error.