### PR TITLE
Hotfix / fix ar defination inconsistency bug 

### DIFF
--- a/opensora/datasets/datasets.py
+++ b/opensora/datasets/datasets.py
@@ -131,7 +131,7 @@ class VariableVideoTextDataset(VideoTextDataset):
         path = sample["path"]
         text = sample["text"]
         file_type = self.get_type(path)
-        ar = width / height
+        ar = height / width
 
         video_fps = 24  # default fps
         if file_type == "video":


### PR DESCRIPTION
I find that the [ar defination in dataset.py](https://github.com/hpcaitech/Open-Sora/blob/4eaaa6cf68fc934aa65fe89b8933db658c7f48c7/opensora/datasets/datasets.py#L134) is inconsistant with others, such as [AR in aspect.py](https://github.com/hpcaitech/Open-Sora/blob/4eaaa6cf68fc934aa65fe89b8933db658c7f48c7/opensora/datasets/aspect.py#L16), [in inference.py](https://github.com/hpcaitech/Open-Sora/blob/4eaaa6cf68fc934aa65fe89b8933db658c7f48c7/scripts/inference.py#L89), etc. Thus this should be a bug which may influence both the training and inference stages. 