### PR TITLE
Fix the CUDA out of memory when load pretrained model

### DIFF
--- a/opensora/models/stdit/stdit2.py
+++ b/opensora/models/stdit/stdit2.py
@@ -517,7 +517,10 @@ def STDiT2_XL_2(from_pretrained=None, **kwargs):
             return model
         else:
             # otherwise, we load the model from hugging face hub
-            return STDiT2.from_pretrained(from_pretrained)
+            config = STDiT2Config.from_pretrained(from_pretrained)
+            config.enable_flash_attn = True
+            config.enable_layernorm_kernel = True
+            return STDiT2.from_pretrained(from_pretrained, config=config)
     else:
         # create a new model
         config = STDiT2Config(


### PR DESCRIPTION
Please see the issue:https://github.com/hpcaitech/Open-Sora/issues/409

Owing to the config discrepancy, when you load pre-trained weight to train, it will forbid acceleration tech.

Fix via the code, or fix via huggingface config.