### PR TITLE
:recycle: Directory creation to use os.makedirs with exist_ok

### DIFF
--- a/opensora/datasets/utils.py
+++ b/opensora/datasets/utils.py
@@ -42,8 +42,7 @@ def read_file(input_path):
 
 def download_url(input_path):
     output_dir = "cache"
-    if not os.path.exists(output_dir):
-        os.makedirs(output_dir)
+    os.makedirs(output_dir, exist_ok=True)
     base_name = os.path.basename(input_path)
     output_path = os.path.join(output_dir, base_name)
     img_data = requests.get(input_path).content


### PR DESCRIPTION
- Simplified code and improved readability
- Ensured functionality remains the same by allowing directory to exist without error