### PR TITLE
fix some typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ See our **[report 1.1](docs/report_02.md)** for more infomation.
 <summary>View more</summary>
 
 | Resolution | Model Size | Data   | #iterations | Batch Size | GPU days (H800) | URL                                                                                           |
-| ---------- | ---------- | ------ | ----------- | ---------- | --------------- |
+| ---------- | ---------- | ------ | ----------- | ---------- | --------------- |--------------------------------------------------------------------------------------------- |
 | 16×512×512 | 700M       | 20K HQ | 20k         | 2×64       | 35              | [:link:](https://huggingface.co/hpcai-tech/Open-Sora/blob/main/OpenSora-v1-HQ-16x512x512.pth) |
 | 16×256×256 | 700M       | 20K HQ | 24k         | 8×64       | 45              | [:link:](https://huggingface.co/hpcai-tech/Open-Sora/blob/main/OpenSora-v1-HQ-16x256x256.pth) |
 | 16×256×256 | 700M       | 366K   | 80k         | 8×64       | 117             | [:link:](https://huggingface.co/hpcai-tech/Open-Sora/blob/main/OpenSora-v1-16x256x256.pth)    |


### PR DESCRIPTION
There are some problems in displaying the table of ` Open-Sora1.0 Model Weights`, as shown below: 

![image](https://github.com/hpcaitech/Open-Sora/assets/108873423/60662c14-d59b-483c-acc3-461aa4253ad9)


And this PR will fix this issue: 
![image](https://github.com/hpcaitech/Open-Sora/assets/108873423/a323537a-04a9-40a5-b579-6d406aaf35c4)

Thanks for the great open-source work maintained by all of you!