### PR TITLE
fix:multi-fps bug. 

### DIFF
--- a/opensora/datasets/datasets.py
+++ b/opensora/datasets/datasets.py
@@ -143,6 +143,8 @@ class VariableVideoTextDataset(VideoTextDataset):
             # Sampling video frames
             video = temporal_random_crop(vframes, num_frames, self.frame_interval)
 
+            video_fps = video_fps // self.frame_interval
+            
             # transform
             transform = get_transforms_video(self.transform_name, (height, width))
             video = transform(video)  # T C H W


### PR DESCRIPTION
For multi-fps training, when extracting frames according to a certain frame_interval, the fps of the extracted frames actually changes. So the fps should be:

video_fps = video_fps // self.frame_interval