### PR TITLE
fix(docs): correct image path in zh_CN README.md

### DIFF
--- a/docs/zh_CN/README.md
+++ b/docs/zh_CN/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img src="./assets/readme/icon.png" width="250"/>
+    <img src="../../assets/readme/icon.png" width="250"/>
 </p>
 <div align="center">
     <a href="https://github.com/hpcaitech/Open-Sora/stargazers"><img src="https://img.shields.io/github/stars/hpcaitech/Open-Sora?style=social"></a>


### PR DESCRIPTION
This PR fixes the image path in the `docs/zh_CN/README.md` file. The incorrect relative path for the image has been updated to ensure the image displays correctly.