### PR TITLE
Fix SeqParallelMultiHeadCrossAttention for consistent results in distributed mode

### DIFF
--- a/opensora/models/layers/blocks.py
+++ b/opensora/models/layers/blocks.py
@@ -499,8 +499,8 @@ class SeqParallelMultiHeadCrossAttention(MultiHeadCrossAttention):
 
         # shape:
         # q, k, v: [B, SUB_N, NUM_HEADS, HEAD_DIM]
-        q = self.q_linear(x).view(1, -1, self.num_heads, self.head_dim)
-        kv = self.kv_linear(cond).view(1, -1, 2, self.num_heads, self.head_dim)
+        q = self.q_linear(x).view(B, -1, self.num_heads, self.head_dim)
+        kv = self.kv_linear(cond).view(B, -1, 2, self.num_heads, self.head_dim)
         kv = split_forward_gather_backward(kv, get_sequence_parallel_group(), dim=3, grad_scale="down")
         k, v = kv.unbind(2)
 


### PR DESCRIPTION
Currently implementation of `SeqParallelMultiHeadCrossAttention` will produce different results.

For example, executing `python scripts/inference.py configs/opensora-v1-2/inference/sample.py --num-frames 1 --resolution 720p --aspect-ratio 9:16 --prompt "a beautiful waterfall" --verbose 2` produces the following image:

![sample_0000](https://github.com/hpcaitech/Open-Sora/assets/23658877/a53efeca-b3a2-482d-b96a-af2f1214112f)

However, running with two GPUs by `torchrun --nproc_per_node 2 scripts/inference.py configs/opensora-v1-2/inference/sample.py --num-frames 1 --resolution 720p --aspect-ratio 9:16 --prompt "a beautiful waterfall" --verbose 2` will produce:

![sample_0000](https://github.com/hpcaitech/Open-Sora/assets/23658877/0ebd69cb-53fe-455c-863e-63e19bf9d3f5)

While both results look marvelous, it would be better to keep the results consistent among different distributed settings. The reason why they are not consistent is because the tensor Q is not reshaped correctly before conducting `all_to_all` among different ranks. 

If I understand correctly, Q has a shape of `[1, (B, SUB_N), NUM_HEADS, HEAD_DIM]` before `all_to_all`, after which we expect Q's shape to be `[1, (B, SP, SUB_N), SUB_NUM_HEADS, HEAD_DIM]` (where `SP` denotes the distributed world size). However, `all_to_all` simply concatentes among the gather dimension. Thus, what we actually get is `[1, (SP, B, SUB_N), SUB_NUM_HEADS, HEAD_DIM]`. We can fix it either through the proposed changes in this pull request, or conduct an transpose as follows, after which we can observe a consistent result regardless of different distributed settings:

```diff
--- a/opensora/models/layers/blocks.py
+++ b/opensora/models/layers/blocks.py
@@ -506,6 +506,9 @@ class SeqParallelMultiHeadCrossAttention(MultiHeadCrossAttention):
 
         # apply all_to_all to gather sequence and split attention heads
         q = all_to_all(q, sp_group, scatter_dim=2, gather_dim=1)
+        q = q.view(sp_size, B, SUB_N, self.num_heads // sp_size, self.head_dim)
+        q = q.transpose(0, 1)
+        q = q.contiguous()
 
         q = q.view(1, -1, self.num_heads // sp_size, self.head_dim)
         k = k.view(1, -1, self.num_heads // sp_size, self.head_dim)
```