### PR TITLE
lint: unify setting in `pyproject.toml`

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,7 +1,0 @@
-[settings]
-line_length = 120
-multi_line_output=3
-include_trailing_comma = true
-ignore_comments = true
-profile = black
-honor_noqa = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     hooks:
       - id: autoflake
         name: autoflake (python)
-        args: ['--in-place', '--remove-unused-variables', '--remove-all-unused-imports', '--ignore-init-module-imports']
+        args: ['--in-place']
 
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
@@ -18,7 +18,6 @@ repos:
     hooks:
     - id: black
       name: black formatter
-      args: ['--line-length=120', '--target-version=py37', '--target-version=py38', '--target-version=py39','--target-version=py310']
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0

--- a/eval/vbench/calc_vbench.py
+++ b/eval/vbench/calc_vbench.py
@@ -3,7 +3,6 @@ import os
 import time
 
 import torch
-
 from vbench import VBench
 
 full_info_path = "eval/vbench/VBench_full_info.json"

--- a/eval/vbench_i2v/calc_vbench_i2v.py
+++ b/eval/vbench_i2v/calc_vbench_i2v.py
@@ -3,7 +3,6 @@ import os
 import time
 
 import torch
-
 from vbench import VBench
 from vbench2_beta_i2v import VBenchI2V
 

--- a/opensora/datasets/read_video.py
+++ b/opensora/datasets/read_video.py
@@ -126,7 +126,6 @@ def _read_from_stream(
     stream_name: Dict[str, Optional[Union[int, Tuple[int, ...], List[int]]]],
     filename: Optional[str] = None,
 ) -> List["av.frame.Frame"]:
-
     if pts_unit == "sec":
         # TODO: we should change all of this from ground up to simply take
         # sec and convert to MS in C++

--- a/opensora/schedulers/rf/rectified_flow.py
+++ b/opensora/schedulers/rf/rectified_flow.py
@@ -19,7 +19,7 @@ def timestep_transform(
     for key in ["height", "width", "num_frames"]:
         if model_kwargs[key].dtype == torch.float16:
             model_kwargs[key] = model_kwargs[key].float()
-            
+
     t = t / num_timesteps
     resolution = model_kwargs["height"] * model_kwargs["width"]
     ratio_space = (resolution / base_resolution).sqrt()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.autoflake]
+remove-unused-variables = true
+remove-all-unused-imports = true
+ignore-init-module-imports = true
+
+[tool.isort]
+line_length = 120
+multi_line_output = 3
+include_trailing_comma = true
+ignore_comments = true
+profile = "black"
+honor_noqa = true
+
+[tool.black]
+line-length = 120
+target-version = ["py37", "py38", "py39", "py310"]


### PR DESCRIPTION
Having all lint configurations in a single file will reduce collision if linters are called as part of pre-commit or individually as `isort` or `black`