### PR TITLE
Import Tuple from typing instead of torch

### DIFF
--- a/opensora/models/mmdit/math.py
+++ b/opensora/models/mmdit/math.py
@@ -2,7 +2,8 @@ import torch
 from einops import rearrange
 from flash_attn import flash_attn_func as flash_attn_func_v2
 from liger_kernel.ops.rope import LigerRopeFunction
-from torch import Tensor, Tuple
+from torch import Tensor
+from typing import Tuple
 
 try:
     from flash_attn_interface import flash_attn_func as flash_attn_func_v3


### PR DESCRIPTION
Importing Tuple from torch didn't work for me (maybe devs used a custom version?), importing it normally from typing works fine.