### PR TITLE
[ckpt] mitigate gpu mem peak when loading ckpt

### DIFF
--- a/opensora/utils/ckpt.py
+++ b/opensora/utils/ckpt.py
@@ -113,8 +113,7 @@ def load_checkpoint(
 
     log_message(f"Loading checkpoint from {path}")
     if path.endswith(".safetensors"):
-        # ckpt = load_file(path, device=str(device_map))
-        ckpt = load_file(path, device=torch.cuda.current_device())
+        ckpt = load_file(path, device='cpu')
 
         if rename_keys is not None:
             # rename keys in the loaded state_dict with old_key_prefix to with new_key_prefix.


### PR DESCRIPTION
This PR will mitigate #834.

Model weights consume extra mem (i.e. 2 x model_size) and cause mem peaks during loading:
![image](https://github.com/user-attachments/assets/1320c693-709c-4e20-8e94-1db432768cd7)
Zoom in:
<img width="828" alt="image" src="https://github.com/user-attachments/assets/22892f8e-546e-4f61-a7dd-ade7e6d5c055" />

`load_state_dict` should be able to load weights even when tensors are not on the save devices.

After fix:
<img width="890" alt="image" src="https://github.com/user-attachments/assets/e2a16e53-0c5d-4314-806e-814cddd7ad39" />


