### PR TITLE
fix a bug that caused to pop all `v2v` conditions during training

### DIFF
--- a/opensora/utils/train.py
+++ b/opensora/utils/train.py
@@ -202,6 +202,8 @@ def prepare_visual_condition_uncausal(
     C = model_ae.cfg.latent_channels
     T, H, W = model_ae.get_latent_size(x.shape[-3:])
 
+    condition_config = condition_config.copy()  # prevent altering the global config when applying local changes
+
     # Initialize masks tensor to match the shape of x, but only the time dimension will be masked
     masks = torch.zeros(B, 1, T, H, W).to(
         x.device, x.dtype
@@ -329,6 +331,8 @@ def prepare_visual_condition_causal(x: torch.Tensor, condition_config: dict, mod
     B = x.shape[0]
     C = model_ae.cfg.latent_channels
     T, H, W = model_ae.get_latent_size(x.shape[-3:])
+
+    condition_config = condition_config.copy()  # prevent altering the global config when applying local changes
 
     # Initialize masks tensor to match the shape of x, but only the time dimension will be masked
     masks = torch.zeros(B, 1, T, H, W).to(

--- a/scripts/diffusion/train.py
+++ b/scripts/diffusion/train.py
@@ -372,7 +372,7 @@ def main():
             # == prepare condition ==
             if cfg.get("condition_config", None) is not None:
                 # condition for i2v & v2v
-                x_0, cond = prepare_visual_condition(x, cfg.condition_config.copy(), model_ae)
+                x_0, cond = prepare_visual_condition(x, cfg.condition_config, model_ae)
                 cond = pack(cond, patch_size=cfg.get("patch_size", 2))
                 inp["cond"] = cond
             else:


### PR DESCRIPTION
This PR fixes condition config mutation in `prepare_visual_condition` during training. Specifically, because dictionaries are passed by reference, even a single short video would be enough to completely remove `v2v_head`, `v2v_tail`, `v2v_head_easy`, and `v2v_tail_easy` from the condition config.