### PR TITLE
Fix issue on VAE inference saving output only on main process

### DIFF
--- a/scripts/vae/inference.py
+++ b/scripts/vae/inference.py
@@ -125,7 +125,7 @@ def main():
                 )
 
             # == save samples ==
-            if is_main_process() and save_dir is not None:
+            if save_dir is not None:
                 for idx, x_orig in enumerate(x):
                     fname = os.path.splitext(os.path.basename(path[idx]))[0]
                     save_path_orig = os.path.join(save_dir_orig, f"{fname}_orig")


### PR DESCRIPTION
When using multiple GPUs in combination with `torchrun --nproc_per_node 1 ...`  inference saves the decoder output only on main process ignoring the output coming from the rest of the GPUs. This  is not the expected behavior.